### PR TITLE
ArduinoJson 7.4 conformity, file instead of stream processing, return value to update_date, debug switch, SPI RAM support, minor code cleaning

### DIFF
--- a/include/weather_rfp.hpp
+++ b/include/weather_rfp.hpp
@@ -33,6 +33,10 @@
 #define ESPWeatherRFPFactorDewPoint 500.0f
 #endif
 
+#ifndef HAS_SPI_RAM_WEATHERRFP
+#define HAS_SPI_RAM_WEATHERRFP 1
+#endif
+
 // Weather Class with Reduced FootPrint (RFP)
 class WeatherRFP
 {
@@ -92,5 +96,21 @@ public:
   String get_symbol_code_next_6h();
   String get_symbol_code_next_12h();
 };
+
+#if HAS_SPI_RAM_WEATHERRFP
+struct SpiRamAllocator : ArduinoJson::Allocator {
+  void* allocate(size_t size) override {
+    return heap_caps_malloc(size, MALLOC_CAP_SPIRAM);
+  }
+
+  void deallocate(void* pointer) override {
+    heap_caps_free(pointer);
+  }
+
+  void* reallocate(void* ptr, size_t new_size) override {
+    return heap_caps_realloc(ptr, new_size, MALLOC_CAP_SPIRAM);
+  }
+};
+#endif
 
 #endif

--- a/include/weather_rfp.hpp
+++ b/include/weather_rfp.hpp
@@ -33,6 +33,9 @@
 #define ESPWeatherRFPFactorDewPoint 500.0f
 #endif
 
+#ifndef DEBUG_WEATHER
+#define DEBUG_WEATHER 1
+#endif
 #ifndef HAS_SPI_RAM_WEATHERRFP
 #define HAS_SPI_RAM_WEATHERRFP 1
 #endif

--- a/include/weather_rfp.hpp
+++ b/include/weather_rfp.hpp
@@ -2,6 +2,9 @@
 #define WEATHER_RFP_HPP
 
 #include <Arduino.h>
+#include <ArduinoJson.h>
+#include <FS.h>
+
 #include "weather_data_rfp.hpp"
 #include "weather_defines.hpp"
 
@@ -44,6 +47,7 @@ private:
   uint16_t altitude;
   int8_t utc_offset;
   const char *url = "https://api.met.no/weatherapi/locationforecast/2.0/complete";
+  const char *scratch_file = "/weather_rfp.json";
   uint8_t num_hours;
   WeatherDataRFP *dew_point;
   WeatherDataRFP *temperature;
@@ -65,7 +69,7 @@ public:
   WeatherRFP(uint8_t num_hours, float latitude, float longitude, uint16_t altitude);
   ~WeatherRFP();
   bool is_expired(void);
-  void update_data(void);
+  bool update_data(fs::FS &fs);
   void update_location(float latitude, float longitude);
   void update_location(float latitude, float longitude, uint16_t altitude);
   void set_utc_offset(int8_t utf_offset);

--- a/src/weather_rfp.cpp
+++ b/src/weather_rfp.cpp
@@ -252,16 +252,13 @@ bool WeatherRFP::update_data(fs::FS &fs)
         this->last_modified = https.header("last-modified");
         String expires = https.header("expires");
         const char *expires_c = expires.c_str();
-#ifdef DEBUG_WEATHER
         char *end = strptime(expires_c, "%a, %d %b %Y %H:%M:%S GMT", this->expired_time);
+#if DEBUG_WEATHER
         if ((end == NULL) || end != "\0")
         {
           Serial.print("Found remaining char: ");
           Serial.println(end);
         }
-#endif
-#ifdef DEBUG_WEATHER
-
         Serial.print("last-modified: ");
         Serial.println(this->last_modified);
         Serial.print("expires: ");
@@ -273,7 +270,7 @@ bool WeatherRFP::update_data(fs::FS &fs)
   }
   else
   {
-#ifdef DEBUG_WEATHER
+#if DEBUG_WEATHER
     Serial.print("Error code: ");
     Serial.println(httpResponseCode);
 #endif
@@ -296,8 +293,8 @@ bool WeatherRFP::update_data(fs::FS &fs)
       return false;
   }
 
-#ifdef DEBUG_WEATHER
-  Serial.println("Starting deserialization");
+#if DEBUG_WEATHER
+  Serial.print("Deserializing weather data from file ...");
 #endif
   DeserializationError error = deserializeJson(doc, file, DeserializationOption::Filter(filter));
   // while(file.available()){
@@ -312,9 +309,8 @@ bool WeatherRFP::update_data(fs::FS &fs)
 
   if (error)
   {
-
-#ifdef DEBUG_WEATHER
-    Serial.print("deserializeJson() failed: ");
+#if DEBUG_WEATHER
+    Serial.print("DeserializeJson() failed - error msg: ");
     Serial.println(error.c_str());
 #endif
     return;
@@ -322,6 +318,9 @@ bool WeatherRFP::update_data(fs::FS &fs)
   if (!(doc["properties"]["timeseries"].is<JsonArray>()))
   {
     return;
+#if DEBUG_WEATHER
+    Serial.println("JsonArray properties.timeseries not found in JSON document");
+#endif
   }
   JsonArray timeseries = doc["properties"]["timeseries"];
   float *temps = new float[this->num_hours + 1];
@@ -368,7 +367,7 @@ bool WeatherRFP::update_data(fs::FS &fs)
   this->relative_humidity->update_vals(relative_humidity);
   this->dew_point->update_vals(dew_point);
   int header_collected = https.headers();
-#ifdef DEBUG_WEATHER
+#if DEBUG_WEATHER
   Serial.print("Collected ");
   Serial.print(header_collected);
   Serial.println(" headers:");
@@ -380,14 +379,12 @@ bool WeatherRFP::update_data(fs::FS &fs)
     const char *expires_c = expires.c_str();
     char *end =
         strptime(expires_c, "%a, %d %b %Y %H:%M:%S GMT", this->expired_time);
-#ifdef DEBUG_WEATHER
+#if DEBUG_WEATHER
     if ((end == NULL) || end != "\0")
     {
       Serial.print("Found remaining char: ");
       Serial.println(end);
     }
-#endif
-#ifdef DEBUG_WEATHER
     Serial.print("last-modified: ");
     Serial.println(this->last_modified);
     Serial.print("expires: ");

--- a/src/weather_rfp.cpp
+++ b/src/weather_rfp.cpp
@@ -280,6 +280,9 @@ bool WeatherRFP::update_data(fs::FS &fs)
   }
 
 #if HAS_SPI_RAM_WEATHERRFP
+  SpiRamAllocator allocator;
+  JsonDocument doc(&allocator);
+#else
   JsonDocument doc;
 #endif
   File file = fs.open(scratch_file, FILE_WRITE);

--- a/src/weather_rfp.cpp
+++ b/src/weather_rfp.cpp
@@ -265,7 +265,7 @@ bool WeatherRFP::update_data(fs::FS &fs)
         Serial.println(expires);
 #endif
       }
-      return;
+      return true;
     }
   }
   else
@@ -313,14 +313,14 @@ bool WeatherRFP::update_data(fs::FS &fs)
     Serial.print("DeserializeJson() failed - error msg: ");
     Serial.println(error.c_str());
 #endif
-    return;
+    return false;
   }
   if (!(doc["properties"]["timeseries"].is<JsonArray>()))
   {
-    return;
 #if DEBUG_WEATHER
     Serial.println("JsonArray properties.timeseries not found in JSON document");
 #endif
+    return false;
   }
   JsonArray timeseries = doc["properties"]["timeseries"];
   float *temps = new float[this->num_hours + 1];


### PR DESCRIPTION
Writes json data to scratch file instead of processing it from the TCP stream. Support for any common files system - simply pass FS handle as an argument to update_data. If SPI RAM is available, json processing cann be done in the SPI RAM - simply set switch in headder file to 1.